### PR TITLE
fix header aligment on mobile

### DIFF
--- a/2023/index.html
+++ b/2023/index.html
@@ -32,9 +32,9 @@
 <body id="page-top">
 <!-- Navigation -->
 <nav class="navbar navbar-custom navbar-expand-lg fixed-top" role="navigation">
-    <div class="container-fluid">
-        <a class="navbar-brand" href="index.html">
-            <img src="assets/img/osm.svg" width="30" height="30" alt="osm-logo"/>
+    <div class="container-fluid flex-nowrap">
+        <a class="navbar-brand mx-0 mx-md-3 text-wrap d-flex align-items-center" href="index.html">
+            <img src="assets/img/osm.svg" width="30" height="30" alt="osm-logo" class="me-2"/>
             State of the Map France
         </a>
         <button


### PR DESCRIPTION
Correction du bandeau en haut de l'écran en mobile.
Pour les écrans très petits le texte passe 2 lignes au lieu de sortir de l'écran comme aujourd'hui.

# Avant 
![image](https://user-images.githubusercontent.com/2306550/228965410-7d9e714d-4cab-4b36-bdcd-79b58e873bf2.png)

# Après
![image](https://user-images.githubusercontent.com/2306550/228965813-f92c54de-2baf-4069-8489-57dceaf7625d.png)
