### PR TITLE
Fix path of assets

### DIFF
--- a/2024/src/html/pages/infos.html
+++ b/2024/src/html/pages/infos.html
@@ -64,7 +64,7 @@
         <div class="content-section">
             <h2>Venir à Lyon en train</h2>
             <p>Lyon est très bien desservi par le train : en moins de 5h, vous pouvez venir de tous ces endroits :)</p>
-            <img src="../../img/lyon_train_5h.png">
+            <img src="img/lyon_train_5h.png">
             <br>
             <a href="https://www.chronotrains.com/fr/station/2996944-Lyon/5">Source</a>
             <h3>Gares de Lyon</h3>

--- a/2024/src/html/pages/programme.html
+++ b/2024/src/html/pages/programme.html
@@ -53,7 +53,7 @@
                     Le programme est aussi disponible en
                     <a href="assets/programme.pdf">
                         téléchargement
-                        <span class="pl-1"><img src="../../img/file-pdf-regular.svg" alt="fichier pdf"
+                        <span class="pl-1"><img src="img/file-pdf-regular.svg" alt="fichier pdf"
                                 style="width: 1em" /></span></a>
                 </p>
                 <object data="assets/programme.pdf" type="application/pdf" class="w-100" height="1000">


### PR DESCRIPTION
#169 has fixed partially the problem of assets missing.
On deployed version on Github, assets are missing.
I adds new changes to be sure it's work in production and in github. I have use path used for sponsors icons.