### PR TITLE
Fix contribution page

### DIFF
--- a/2024/src/html/pages/contribution.html
+++ b/2024/src/html/pages/contribution.html
@@ -16,16 +16,16 @@
                 <p>
                     Si vous souhaitez nous contacter, merci d'utiliser l'adresse <a href="mailto:sotm@openstreetmap.fr">sotm@openstreetmap.fr</a>.
                 </p>
-                <div class="row bg-white text-center">
+                <!--<div class="row bg-white text-center">
                     <div class="contributionCall hidden col py-5 text-dark">
                         <p class="fw-medium">L'appel à contributions est clôturé.</p>
                         <p>Si vous souhaitez nous contacter, merci d'utiliser l'adresse <a
                                 href="mailto:sotm@openstreetmap.fr">sotm@openstreetmap.fr</a>.</p>
                     </div>
-                    <!--<div class="contributionCall">
+                    <div class="contributionCall">
                         <iframe src="https://pretalx.com/sotm-fr-2024/cfp"
-                            width="100%" height="800" border="0"></iframe>-->
-                    </div>
+                            width="100%" height="800" border="0"></iframe>
+                    </div>-->
                 </div>
             </div>
         </div>


### PR DESCRIPTION
A l'origine une fonction js a été développé pour cacher et afficher certains éléments de la page contribution après le 01 mai.
Cette pr met les parties concernées en commentaires. Pour ne pas afficher du texte non souhaitée après cette date.