### PR TITLE
Hyperlien TCL depuis Lyon Perrache

### DIFF
--- a/2024/src/html/pages/infos.html
+++ b/2024/src/html/pages/infos.html
@@ -71,7 +71,7 @@
             <p>
             Si vous avez la possibilité, arrêtez-vous à la gare de <strong>Lyon Part-Dieu</strong> puis vous pourrez <a href="https://www.openstreetmap.org/directions?engine=graphhopper_foot&route=45.7606%2C4.8598%3B45.7492%2C4.8601#map=16/45.7549/4.8606" target="_blank">marcher (18 mn, 1,4 km)</a> 
             ou prendre le tram <a href="https://www.tcl.fr/lignes/tramway-t4" target="_blank">T4</a>, coté porte des Alpes, pour venir au Campus de la Manufacture des Tabacs.</p>
-            <p></p>La gare de Perrache est une belle alternative mais il faudra prendre les transports en commun pour nous rejoindre.
+            <p></p>La gare de Perrache est une belle alternative mais il faudra prendre les <a href="https://www.tcl.fr/itineraires?date=now&pmr=0&from=poi%3ATCL%3AGAR%3A20455&to=poi%3Aosm%3Away%3A694531440">transports en commun</a> pour nous rejoindre.
             <p>La gare St Exupéry est à l'aéroport, il est plus compliqué d'arriver en centre-ville : <a href="https://www.rhonexpress.fr/fr_FR/" target="_blank">Navette Rhone-Express</a> (cher) ou un bus <a href="https://www.tcl.fr/" target="_blank">TCL</a> (long).</p>
 
     


### PR DESCRIPTION
Ajout de l'hyperlien suivant -> https://www.tcl.fr/itineraires?date=now&pmr=0&from=poi%3ATCL%3AGAR%3A20455&to=poi%3Aosm%3Away%3A694531440
sur la page infos pour les contributeurs qui arriveraient depuis Lyon Perrache
Cet hyperlien fonctionne tout le temps du fait qu'il a la valeur date=now

![image](https://github.com/osm-fr/sotmfr-website/assets/87148630/5a0e6290-e0be-49fc-bcd5-81461c84d1b2)