### PR TITLE
Ajout de la bannière de l'evt dans les tags SEO

### DIFF
--- a/2024/src/html/layouts/layout.html
+++ b/2024/src/html/layouts/layout.html
@@ -14,6 +14,7 @@
   <meta name="description" content="{{ SEO_description }}">
   <meta name="og:title" content="{{ site_name }} - {{ page_name }}">
   <meta name="og:description" content="{{ SEO_description }}">
+  <meta property="og:image" content="https://sotm2024.openstreetmap.fr/img/2082-sotm2024-logos_Sotm-2024-logo-horizontal.png" />
 
   <link rel="stylesheet" href="css/bootstrap.css" />
   <link rel="stylesheet" href="css/style.css" />


### PR DESCRIPTION
Une remarque a été faite sur Telegram du fait que sur des sites tiers qui mentionnait le site Internet l'encart réservé pour une image était vide.
Un tag a été rajouté en ce sens, j'ai utilisé une vrai url car je ne sais pas si les liens symboliques fonctionnent pour ce tag.
Et je n'ai aucun moyen de tester en local.